### PR TITLE
fix: Resolve static summary, ensure data refresh, and add AI UI

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -92,8 +92,8 @@ func main() {
 
 	// Instantiate handlers
 	// authHandler := handlers.NewAuthHandler(userService) // Removed AuthHandler
-	incomeHandler := handlers.NewIncomeHandler(incomeService)
-	expenseHandler := handlers.NewExpenseHandler(expenseService)
+	incomeHandler := handlers.NewIncomeHandler(incomeService, summaryService) // Added summaryService
+	expenseHandler := handlers.NewExpenseHandler(expenseService, summaryService) // Added summaryService
 	savingsHandler := handlers.NewSavingsHandler(savingsService)
 	debtHandler := handlers.NewDebtHandler(debtService)
 	summaryHandler := handlers.NewSummaryHandler(summaryService)


### PR DESCRIPTION
This commit addresses critical issues related to data staleness on your dashboard and implements the frontend for the AI financial suggestions.

1.  **Fix Static Financial Summary Data & Ensure Refresh:**
    - **Backend:** - I implemented a summary invalidation strategy in `SummaryService`. A new method `InvalidateSummariesForDate` deletes stored "overall" summaries for specified periods (monthly, weekly, yearly) when underlying data changes. - `IncomeHandler` and `ExpenseHandler` now call `InvalidateSummariesForDate` (in a goroutine) after successful Create, Update, or Delete operations on income/expense items. This forces `GetOrCreateFinancialSummary` to recalculate the "overall" summary on subsequent requests. - I refactored delete handlers to fetch an item's date before deletion to ensure correct invalidation.
    - **Frontend (`Dashboard.vue`):**
        - `handleItemChange` (on delete) and `handleFormSubmit` (on add/edit) now call `fetchSummary()`, `fetchExpenseBreakdown()`, and `fetchIncomeExpenseTrend()` to ensure all relevant dashboard data (summary, section lists via key change, analytics) is refreshed after any CUD operation.
        - I verified that `SavingsSection.vue` and `DebtsSection.vue` correctly refresh their lists and trigger dashboard updates.

2.  **Implement Frontend for AI Financial Suggestions:**
    - **Frontend (`Dashboard.vue`):** - I added a new "AI Financial Coach" section. - You can click a "Get AI Advice" button to fetch suggestions. - The UI displays loading states, error messages (with a retry button and specific messages for unconfigured AI features from a 503 status), and the AI-generated advice. - If AI advice is visible, it auto-refreshes when other financial data (triggering summary/analytics refresh) is modified.
    - **Backend (Verified):** I ensured `ai_advice_handler.go` correctly fetches the current month's "overall" summary to provide context for AI advice generation.

3.  **Testing:**
    - I added backend unit tests for `SummaryService.InvalidateSummariesForDate` to cover various invalidation scenarios.
    - I added backend unit tests for `ExpenseService.GetExpenses` to verify date range filtering and pagination.
    - All new and existing service-level tests are passing.

These changes ensure a more dynamic, accurate, and feature-rich dashboard experience for you.